### PR TITLE
Improve App routing tests

### DIFF
--- a/src/__test__/App.test.jsx
+++ b/src/__test__/App.test.jsx
@@ -1,17 +1,60 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import {
   createMemoryRouter,
   RouterProvider,
   createRoutesFromElements,
-  Route
-} from "react-router-dom";
-import RootLayout from "../components/layout/RootLayout";
-import Home from "../components/home/Home";
-import VeterinarianListing from "../components/veterinarian/VeterinarianListing";
-import UserRegistration from "../components/user/UserRegistration";
-import Login from "../components/auth/Login";
-import AdminDashboard from "../components/admin/AdminDashboard";
+  Route,
+  Outlet,
+} from 'react-router-dom';
+
+// Mock route components to avoid rendering the real implementation
+jest.mock('../components/layout/RootLayout', () => {
+  const React = require('react');
+  const { Outlet } = require('react-router-dom');
+  return {
+    __esModule: true,
+    default: () => (
+      <div data-testid="root-layout">
+        <Outlet />
+      </div>
+    ),
+  };
+});
+
+jest.mock('../components/home/Home', () => ({
+  __esModule: true,
+  default: () => <div>Home Page</div>,
+}));
+
+jest.mock('../components/veterinarian/VeterinarianListing', () => ({
+  __esModule: true,
+  default: () => <div>Veterinarian List</div>,
+}));
+
+jest.mock('../components/user/UserRegistration', () => ({
+  __esModule: true,
+  default: () => <div>User Registration Form</div>,
+}));
+
+jest.mock('../components/auth/Login', () => ({
+  __esModule: true,
+  default: () => <div>Login Page</div>,
+}));
+
+jest.mock('../components/admin/AdminDashboard', () => ({
+  __esModule: true,
+  default: () => <div>Admin Dashboard Page</div>,
+}));
+
+const RootLayout = require('../components/layout/RootLayout').default;
+const Home = require('../components/home/Home').default;
+const VeterinarianListing =
+  require('../components/veterinarian/VeterinarianListing').default;
+const UserRegistration = require('../components/user/UserRegistration').default;
+const Login = require('../components/auth/Login').default;
+const AdminDashboard = require('../components/admin/AdminDashboard').default;
 
 const routes = createRoutesFromElements(
   <Route path="/" element={<RootLayout />} errorElement={<h1>Not Found</h1>}>
@@ -19,43 +62,46 @@ const routes = createRoutesFromElements(
     <Route path="doctors" element={<VeterinarianListing />} />
     <Route path="register-user" element={<UserRegistration />} />
     <Route path="login" element={<Login />} />
-    <Route path="admin-dashboard/:userId/admin-dashboard" element={<AdminDashboard />} />
+    <Route
+      path="admin-dashboard/:userId/admin-dashboard"
+      element={<AdminDashboard />}
+    />
   </Route>
 );
 
-function renderWithRouter(initialEntries) {
+const renderWithRouter = (initialEntries) => {
   const router = createMemoryRouter(routes, { initialEntries });
   return render(<RouterProvider router={router} />);
-}
+};
 
-describe("App Routing", () => {
-  test("renders Home component on default route", async () => {
-    renderWithRouter(["/"]);
-    expect(await screen.findByText(/home page/i)).toBeInTheDocument();
+describe('App Routing', () => {
+  test('renders Home component on default route', () => {
+    renderWithRouter(['/']);
+    expect(screen.getByText(/home page/i)).toBeInTheDocument();
   });
 
-  test("renders VeterinarianListing component on /doctors", async () => {
-    renderWithRouter(["/doctors"]);
-    expect(await screen.findByText(/meet our veterinarians/i)).toBeInTheDocument();
+  test('renders VeterinarianListing component on /doctors', () => {
+    renderWithRouter(['/doctors']);
+    expect(screen.getByText(/veterinarian list/i)).toBeInTheDocument();
   });
 
-  test("renders UserRegistration component on /register-user", async () => {
-    renderWithRouter(["/register-user"]);
-    expect(await screen.findByText(/user registration form/i)).toBeInTheDocument();
+  test('renders UserRegistration component on /register-user', () => {
+    renderWithRouter(['/register-user']);
+    expect(screen.getByText(/user registration form/i)).toBeInTheDocument();
   });
 
-  test("renders Login component on /login", async () => {
-    renderWithRouter(["/login"]);
-    expect(await screen.findByText(/login/i)).toBeInTheDocument();
+  test('renders Login component on /login', () => {
+    renderWithRouter(['/login']);
+    expect(screen.getByText(/login page/i)).toBeInTheDocument();
   });
 
-  test("renders AdminDashboard component on /admin-dashboard", async () => {
-    renderWithRouter(["/admin-dashboard/1/admin-dashboard"]);
-    expect(await screen.findByText(/dashboard/i)).toBeInTheDocument();
+  test('renders AdminDashboard component on /admin-dashboard', () => {
+    renderWithRouter(['/admin-dashboard/1/admin-dashboard']);
+    expect(screen.getByText(/admin dashboard page/i)).toBeInTheDocument();
   });
 
-  test("renders Not Found on unknown route", async () => {
-    renderWithRouter(["/unknown-route"]);
-    expect(await screen.findByText(/not found/i)).toBeInTheDocument();
+  test('renders Not Found on unknown route', () => {
+    renderWithRouter(['/unknown-route']);
+    expect(screen.getByText(/not found/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- rewrite App.test.jsx to use Jest and simplified mocked components

## Testing
- `npx jest src/__test__/App.test.jsx --runInBand --reporters=default --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851ae89b730832e86381b927bc0118e