### PR TITLE
Add snapshot tests for action components

### DIFF
--- a/src/__test__/components/actions/ActionButtons.test.jsx
+++ b/src/__test__/components/actions/ActionButtons.test.jsx
@@ -1,6 +1,19 @@
 import React from 'react';
-import Component from '../../../components/actions/ActionButtons.jsx';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ActionButtons from '../../../components/actions/ActionButtons.jsx';
 
-test('renders without crashing', () => {
-  expect(Component).toBeDefined();
+test('renders ActionButtons and handles click', () => {
+  const handleClick = jest.fn();
+  const { asFragment } = render(
+    <ActionButtons title="Test Button" variant="primary" onClick={handleClick} />
+  );
+
+  const button = screen.getByRole('button', { name: /test button/i });
+  expect(button).toBeInTheDocument();
+
+  fireEvent.click(button);
+  expect(handleClick).toHaveBeenCalledTimes(1);
+
+  expect(asFragment()).toMatchSnapshot();
 });

--- a/src/__test__/components/actions/PatientActions.test.jsx
+++ b/src/__test__/components/actions/PatientActions.test.jsx
@@ -1,6 +1,38 @@
 import React from 'react';
-import Component from '../../../components/actions/PatientActions.jsx';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PatientActions from '../../../components/actions/PatientActions.jsx';
 
-test('renders without crashing', () => {
-  expect(Component).toBeDefined();
+const appointment = {
+  id: 1,
+  appointmentDate: '2024-01-01',
+  appointmentTime: '10:00',
+  reason: 'Checkup',
+};
+
+test('renders PatientActions and handles interactions', () => {
+  const onCancel = jest.fn();
+  const onUpdate = jest.fn();
+  const { asFragment } = render(
+    <PatientActions
+      onCancel={onCancel}
+      onUpdate={onUpdate}
+      isDisabled={false}
+      appointment={appointment}
+    />
+  );
+
+  const updateButton = screen.getByRole('button', { name: /update appointment/i });
+  const cancelButton = screen.getByRole('button', { name: /cancel appointment/i });
+
+  expect(updateButton).toBeInTheDocument();
+  expect(cancelButton).toBeInTheDocument();
+
+  fireEvent.click(cancelButton);
+  expect(onCancel).toHaveBeenCalledWith(1);
+
+  fireEvent.click(updateButton);
+  expect(screen.getByText(/save update/i)).toBeInTheDocument();
+
+  expect(asFragment()).toMatchSnapshot();
 });

--- a/src/__test__/components/actions/VeterinarianActions.test.jsx
+++ b/src/__test__/components/actions/VeterinarianActions.test.jsx
@@ -1,6 +1,33 @@
 import React from 'react';
-import Component from '../../../components/actions/VeterinarianActions.jsx';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VeterinarianActions from '../../../components/actions/VeterinarianActions.jsx';
 
-test('renders without crashing', () => {
-  expect(Component).toBeDefined();
+const appointment = { id: 1 };
+
+test('renders VeterinarianActions and handles approve/decline', () => {
+  const onApprove = jest.fn(() => Promise.resolve());
+  const onDecline = jest.fn(() => Promise.resolve());
+  const { asFragment } = render(
+    <VeterinarianActions
+      onApprove={onApprove}
+      onDecline={onDecline}
+      isDisabled={false}
+      appointment={appointment}
+    />
+  );
+
+  const approveButton = screen.getByRole('button', { name: /approve appointment/i });
+  const declineButton = screen.getByRole('button', { name: /decline appointment/i });
+
+  expect(approveButton).toBeInTheDocument();
+  expect(declineButton).toBeInTheDocument();
+
+  fireEvent.click(approveButton);
+  expect(onApprove).toHaveBeenCalledWith(1);
+
+  fireEvent.click(declineButton);
+  expect(onDecline).toHaveBeenCalledWith(1);
+
+  expect(asFragment()).toMatchSnapshot();
 });

--- a/src/__test__/components/actions/__snapshots__/ActionButtons.test.jsx.snap
+++ b/src/__test__/components/actions/__snapshots__/ActionButtons.test.jsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders ActionButtons and handles click 1`] = `
+<DocumentFragment>
+  <button
+    class="btn btn-primary btn-sm"
+    type="button"
+  >
+    Test Button
+  </button>
+</DocumentFragment>
+`;

--- a/src/__test__/components/actions/__snapshots__/PatientActions.test.jsx.snap
+++ b/src/__test__/components/actions/__snapshots__/PatientActions.test.jsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders PatientActions and handles interactions 1`] = `
+<DocumentFragment>
+  <section
+    class="d-flex justify-content-end gap-2 mt-2 mb-2"
+  >
+    <button
+      class="btn btn-warning btn-sm"
+      type="button"
+    >
+      Update Appointment
+    </button>
+    <button
+      class="btn btn-danger btn-sm"
+      type="button"
+    >
+      Cancel Appointment
+    </button>
+  </section>
+</DocumentFragment>
+`;

--- a/src/__test__/components/actions/__snapshots__/VeterinarianActions.test.jsx.snap
+++ b/src/__test__/components/actions/__snapshots__/VeterinarianActions.test.jsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders VeterinarianActions and handles approve/decline 1`] = `
+<DocumentFragment>
+  <section
+    class="d-flex justify-content-end gap-2 mt-2 mb-2"
+  >
+    <button
+      class="btn btn-success btn-sm"
+      type="button"
+    >
+      Approve Appointment
+    </button>
+    <button
+      class="btn btn-secondary btn-sm"
+      type="button"
+    >
+      <div
+        class="text-center"
+      >
+        <span
+          aria-hidden="true"
+          class="spinner-border spinner-border-sm"
+          role="status"
+        />
+        <span
+          class="sr-only"
+        >
+          Declining appointment...
+        </span>
+      </div>
+    </button>
+  </section>
+</DocumentFragment>
+`;


### PR DESCRIPTION
## Summary
- expand ActionButtons tests with click event and snapshot
- add interaction tests with snapshots for PatientActions
- add approve/decline behavior test with snapshot for VeterinarianActions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685270262a8c832eb5253f7318010c0f